### PR TITLE
Fixed a problem when empty strings were not converted properly

### DIFF
--- a/Processor.php
+++ b/Processor.php
@@ -114,7 +114,7 @@ class Processor
         $params = array();
         foreach ($envMap as $param => $env) {
             $value = getenv($env);
-            if ($value) {
+            if ($value !== false) {
                 if (in_array(strtolower($value), ['true', 'false'])) {
                     $params[$encloseChar . $param . $encloseChar] = $value;
                 } else {


### PR DESCRIPTION
Let's make sure that doesn't break our live deployments (but it definitely is not supposed to)!

Unset environment variables and empty are different!

```
$ MEM_DATA= php -a
Interactive shell

php > var_dump(getenv('MEM_DATA'));
string(0) ""
php > ^D

$ php -a
Interactive shell

php > var_dump(getenv('MEM_DATA'));
bool(false)
```
